### PR TITLE
fix: Handle NaN values when loading from Excel

### DIFF
--- a/ccpm_module.py
+++ b/ccpm_module.py
@@ -111,10 +111,15 @@ class Resource:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Resource":
+        non_working_days_str = data.get("non_working_days")
+        non_working_days = []
+        if pd.notna(non_working_days_str) and non_working_days_str:
+            non_working_days = [int(d.strip()) for d in str(non_working_days_str).split(',') if d.strip()]
+
         return cls(
             resource_id=data["id"],
             name=data["name"],
-            non_working_days=data.get("non_working_days", []),
+            non_working_days=non_working_days,
             capacity_per_day=data.get("capacity_per_day", 1),
         )
 
@@ -237,11 +242,17 @@ class Task:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Task":
         """Deserializes task from a dictionary."""
+        # print(f"DEBUG: Loading task from data: {data}") # Temporary debug logging
+
         resources_str = data.get("resources", "")
-        resources = [r.strip() for r in str(resources_str).split(",") if r.strip() and pd.notna(resources_str)]
+        if pd.isna(resources_str):
+            resources_str = ""
+        resources = [r.strip() for r in str(resources_str).split(',') if r.strip()]
 
         predecessors_str = data.get("predecessors", "")
-        preds = [p.strip() for p in str(predecessors_str).split(",") if p.strip() and pd.notna(predecessors_str)]
+        if pd.isna(predecessors_str):
+            predecessors_str = ""
+        preds = [p.strip() for p in str(predecessors_str).split(',') if p.strip()]
 
         t = cls(
             task_id=data["id"],

--- a/scenario_multi_calendar_output.txt
+++ b/scenario_multi_calendar_output.txt
@@ -1,0 +1,15 @@
+Loading project from scenario_multi_calendar.xlsx...
+Loaded 7 tasks and 3 resources
+Creating CCPM schedule...
+Running full CCPM scheduling pipeline...
+CCPM Schedule created successfully.
+
+============================================================
+CCPM SCHEDULE SUMMARY
+============================================================
+Total Tasks: 10
+Completed Tasks: 0
+Progress: 0.0%
+Critical Chain Length: 4 tasks
+Project Duration: 362 days
+Total Safety Removed: 34 days


### PR DESCRIPTION
This commit fixes a bug where the application would crash with a `TypeError: 'float' object is not iterable` when loading project data from an Excel file that had been opened and saved in Excel. This was caused by pandas reading empty cells as `NaN` values, which were not handled correctly in the data loading logic.

The main changes include:
- The `Resource.from_dict` method in `ccpm_module.py` has been updated to be more robust against `NaN` values in the `non_working_days` field.
- The `Task.from_dict` method in `ccpm_module.py` has been updated to be more robust against `NaN` values in the `predecessors` and `resources` fields.

This fix ensures that the application can now correctly load project data from Excel files, even if they contain empty cells that have been converted to `NaN`. All tests pass.